### PR TITLE
Guarantee that Mash output is produced even for empty input

### DIFF
--- a/modules/mash.nf
+++ b/modules/mash.nf
@@ -13,7 +13,7 @@ process mash_sketch {
     script:
       output_basename = reads_1.baseName.split('\\.')[0]
       """
-      mash sketch -r ${reads_1} -m ${params.mash_sketch_minimum_copies} -k ${params.mash_sketch_kmer_size} -C ${output_basename} -o ${output_basename} &> ${output_basename}_mash_sketch.txt
+      mash sketch -r ${reads_1} -m ${params.mash_sketch_minimum_copies} -k ${params.mash_sketch_kmer_size} -C ${output_basename} -o ${output_basename} &> ${output_basename}_mash_sketch.txt || echo -e "Estimated genome size: 0.0\nEstimated coverage:    0.0" > ${output_basename}_mash_sketch.txt
       """
 }
 


### PR DESCRIPTION
Fixes #46 